### PR TITLE
Fix pop() method bug(java)

### DIFF
--- a/codes/java/chapter_heap/my_heap.java
+++ b/codes/java/chapter_heap/my_heap.java
@@ -89,14 +89,16 @@ class MaxHeap {
         // 判空处理
         if (isEmpty())
             throw new IndexOutOfBoundsException();
+        //保存堆顶值
+        int rootVal = maxHeap.get(0);
         // 交换根节点与最右叶节点（交换首元素与尾元素）
         swap(0, size() - 1);
         // 删除节点
-        int val = maxHeap.remove(size() - 1);
+        maxHeap.remove(size() - 1);
         // 从顶至底堆化
         siftDown(0);
         // 返回堆顶元素
-        return val;
+        return rootVal;
     }
 
     /* 从节点 i 开始，从顶至底堆化 */


### PR DESCRIPTION
Ensure pop() correctly returns the original heap top value by saving it before swapping and removing the last element.

If this pull request (PR) pertains to **Chinese-to-English translation**, please confirm that you have read the contribution guidelines and complete the checklist below:

- [ ] This PR represents the translation of a single, complete document, or contains only bug fixes.
- [ ] The translation accurately conveys the original meaning and intent of the Chinese version. If deviations exist, I have provided explanatory comments to clarify the reasons.

If this pull request (PR) is associated with **coding or code transpilation**, please attach the relevant console outputs to the PR and complete the following checklist:

- [ ] I have thoroughly reviewed the code, focusing on its formatting, comments, indentation, and file headers.
- [ ] I have confirmed that the code execution outputs are consistent with those produced by the reference code (Python or Java).
- [ ] The code is designed to be compatible on standard operating systems, including Windows, macOS, and Ubuntu.
